### PR TITLE
Allow "Censored Phrases" to be modified during runtime 

### DIFF
--- a/app/scrubber.cpp
+++ b/app/scrubber.cpp
@@ -276,12 +276,15 @@ void Scrubber::Run() {
       ImGui::ListBox("Censored Words", &item_current, items, this->censored_phrases.size(), 10);
 
       if (ImGui::Button("+")) {
-        this->censored_phrases.insert(this->censored_phrases.begin(), this->new_phrase);
+        // this->censored_phrases.insert(this->censored_phrases.begin(), this->new_phrase);
+        AddCensoredPhrase(this->new_phrase);
       }
       ImGui::SameLine();
       ImGui::InputText("##", this->new_phrase, 64);
       ImGui::SameLine();
-      if (ImGui::Button("-")) {}
+      if (ImGui::Button("-")) {
+        RemoveCensoredPhrase(this->new_phrase);
+      }
 
       ImGui::Text("Application average %.3f ms/frame (%.1f FPS)", 1000.0f / io.Framerate, io.Framerate);
       ImGui::End();
@@ -333,12 +336,29 @@ void Scrubber::Run() {
 }
 
 bool Scrubber::AddCensoredPhrase(const char* phrase) {
-  if (!(std::find(this->censored_phrases.begin(), this->censored_phrases.end(), phrase) !=
-        this->censored_phrases.end())) {
+  if ((std::find(this->censored_phrases.begin(), this->censored_phrases.end(), phrase) !=
+       this->censored_phrases.end())) {
     return false;
   }
 
   this->censored_phrases.insert(this->censored_phrases.begin(), phrase);
 
   return true;
+}
+
+bool Scrubber::RemoveCensoredPhrase(const char* phrase) {
+  if (!(std::find(this->censored_phrases.begin(), this->censored_phrases.end(), phrase) !=
+        this->censored_phrases.end())) {
+    return false;
+  }
+
+  size_t i;
+  for (i = 0; i < this->censored_phrases.size(); i++) {
+    if (strcmp(this->censored_phrases.at(i).c_str(), phrase) == 0) {
+      this->censored_phrases.erase(this->censored_phrases.begin() + i);
+      return true;
+    }
+  }
+
+  return false;
 }

--- a/app/scrubber.cpp
+++ b/app/scrubber.cpp
@@ -274,6 +274,13 @@ void Scrubber::Run() {
       static int item_current = 1;
       ImGui::ListBox("Censored Words", &item_current, items, this->censored_phrases.size(), 10);
 
+      if (ImGui::Button("+")) {}
+      ImGui::SameLine();
+      char* new_phrase = (char*)malloc(sizeof(char) * (64 + 1));
+      ImGui::InputText("##", new_phrase, 64);
+      ImGui::SameLine();
+      if (ImGui::Button("-")) {}
+
       ImGui::Text("Application average %.3f ms/frame (%.1f FPS)", 1000.0f / io.Framerate, io.Framerate);
       ImGui::End();
     }

--- a/app/scrubber.cpp
+++ b/app/scrubber.cpp
@@ -100,12 +100,16 @@ void Scrubber::CreateSaveFiles() {
     exit(1);
   }
 
+  std::string path = this->kSavePath;
+  path += "/config.json";
+
+  if (std::filesystem::exists(path)) {
+    return;
+  }
+
   nlohmann::json config;
   config["censored_phrases"] = {"ass",  "bitch", "cock", "cunt", "dick", "fuck",
                                 "piss", "pussy", "shit", "slut", "whore"};
-
-  std::string path = this->kSavePath;
-  path += "/config.json";
 
   std::ofstream file(path.c_str());
   file << config;

--- a/app/scrubber.cpp
+++ b/app/scrubber.cpp
@@ -65,6 +65,7 @@ Scrubber::Scrubber() {
 
   // States
   this->display_modifiers = true;
+  this->new_phrase = (char*)malloc(sizeof(char) * (64 + 1));
 }
 
 void Scrubber::CreateSaveDirectory() {
@@ -274,10 +275,11 @@ void Scrubber::Run() {
       static int item_current = 1;
       ImGui::ListBox("Censored Words", &item_current, items, this->censored_phrases.size(), 10);
 
-      if (ImGui::Button("+")) {}
+      if (ImGui::Button("+")) {
+        this->censored_phrases.insert(this->censored_phrases.begin(), this->new_phrase);
+      }
       ImGui::SameLine();
-      char* new_phrase = (char*)malloc(sizeof(char) * (64 + 1));
-      ImGui::InputText("##", new_phrase, 64);
+      ImGui::InputText("##", this->new_phrase, 64);
       ImGui::SameLine();
       if (ImGui::Button("-")) {}
 
@@ -328,4 +330,15 @@ void Scrubber::Run() {
   SDL_Quit();
 
   exit(0);
+}
+
+bool Scrubber::AddCensoredPhrase(const char* phrase) {
+  if (!(std::find(this->censored_phrases.begin(), this->censored_phrases.end(), phrase) !=
+        this->censored_phrases.end())) {
+    return false;
+  }
+
+  this->censored_phrases.insert(this->censored_phrases.begin(), phrase);
+
+  return true;
 }

--- a/app/scrubber.cpp
+++ b/app/scrubber.cpp
@@ -123,6 +123,19 @@ void Scrubber::LoadConfig() {
   this->censored_phrases = config.at("censored_phrases");
 }
 
+bool Scrubber::SaveConfig() {
+  nlohmann::json config;
+  config["censored_phrases"] = this->censored_phrases;
+
+  std::string path = this->kSavePath;
+  path += "/config.json";
+
+  std::ofstream file(path.c_str());
+  file << config;
+
+  return true;
+}
+
 void Scrubber::StyleColorsScrubber() {
   auto& colors = ImGui::GetStyle().Colors;
   colors[ImGuiCol_WindowBg] = ImVec4{0.1f, 0.1f, 0.13f, 1.0f};
@@ -323,6 +336,8 @@ void Scrubber::Run() {
     ImGui_ImplSDLRenderer2_RenderDrawData(ImGui::GetDrawData());
     SDL_RenderPresent(this->renderer);
   }
+
+  SaveConfig();
 
   // Cleanup
   delete[] this->kSavePath;

--- a/app/scrubber.hpp
+++ b/app/scrubber.hpp
@@ -11,6 +11,7 @@ class Scrubber {
   /// @brief A list of censored phrases
   std::vector<std::string> censored_phrases;
   bool display_modifiers;
+  char* new_phrase;
 
   IntVector2 preview_image_size;
 
@@ -29,6 +30,11 @@ class Scrubber {
 
   /// @brief Starts the application
   void Run();
+
+  /// @brief Add a phrase to censor. Prevents duplicates.
+  /// @param phrase The phrase you want to censor.
+  /// @return true if successful
+  bool AddCensoredPhrase(const char* phrase);
 
  private:
   SDL_Window* window;

--- a/app/scrubber.hpp
+++ b/app/scrubber.hpp
@@ -36,6 +36,11 @@ class Scrubber {
   /// @return true if successful
   bool AddCensoredPhrase(const char* phrase);
 
+  /// @brief Uncensors a phrase.
+  /// @param phrase The phrase you want to uncensor.
+  /// @return true if successful
+  bool RemoveCensoredPhrase(const char* phrase);
+
  private:
   SDL_Window* window;
   SDL_Renderer* renderer;

--- a/app/scrubber.hpp
+++ b/app/scrubber.hpp
@@ -54,4 +54,8 @@ class Scrubber {
   void CreateSaveFiles();
 
   void LoadConfig();
+
+  /// @brief Saves config into a JSON file.
+  /// @return true if successful
+  bool SaveConfig();
 };


### PR DESCRIPTION
Fixes: https://github.com/novialriptide/scrubber/issues/3

## Tasks
 - [x] Add GUI elements
 - [x] Make the `+` button functional
 - [x] Make the `-` button functional
 - [x] Save censored words to JSON file